### PR TITLE
Enable the detection of container-formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ lib/
 /.lein-failures
 /*.jar
 /pom.xml
+target/
+.DS_Store

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,10 @@
-(defproject clj-tika "1.2.0"
+(defproject org.clojars.floriano.clj-tika "1.2.3"
   :description "Clojure bindings to Apache Tika"
+  :url "https://github.com/FlorianO/clj-tika"
+  :license {:name "Eclipse Public License - v 1.0"
+            :url "http://www.eclipse.org/legal/epl-v10.html"
+            :distribution :repo
+            :comments "same as Clojure"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.apache.tika/tika-parsers "1.2"]]
+                 [org.apache.tika/tika-parsers "1.3"]]
   )

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject org.clojars.floriano.clj-tika "1.2.4"
+(defproject org.clojars.floriano.clj-tika "1.2.5-SNAPSHOT"
   :description "Clojure bindings to Apache Tika"
   :url "https://github.com/FlorianO/clj-tika"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.apache.tika/tika-parsers "1.4"]]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.apache.tika/tika-parsers "1.5"]]
   )

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.floriano.clj-tika "1.2.3"
+(defproject org.clojars.floriano.clj-tika "1.2.4"
   :description "Clojure bindings to Apache Tika"
   :url "https://github.com/FlorianO/clj-tika"
   :license {:name "Eclipse Public License - v 1.0"
@@ -6,5 +6,5 @@
             :distribution :repo
             :comments "same as Clojure"}
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.apache.tika/tika-parsers "1.3"]]
+                 [org.apache.tika/tika-parsers "1.4"]]
   )

--- a/src/tika.clj
+++ b/src/tika.clj
@@ -7,13 +7,14 @@
            [org.apache.tika.metadata Metadata]
            [org.apache.tika Tika]
            [org.apache.tika.sax BodyContentHandler]
+           [org.apache.tika.io TikaInputStream]
            )
   (:use [clojure.java.io :only [input-stream]])
   )
 
 ;; TODO: add separate function to extract only meta-data
 
-(def ^{:private true} tika-class (Tika.))
+(def ^Tika ^{:private true} tika-class (Tika.))
 
 (defn conv-metadata [^Metadata mdata]
   (let [names (.names mdata)]
@@ -38,21 +39,21 @@
            (.parse parser ifile handler metadata context)
            (assoc (conv-metadata metadata) :text (.toString handler))))
   (detect-mime-type [^InputStream ifile]
-                    (.detect tika-class ifile)))
+                    (.detect tika-class (TikaInputStream/get ifile))))
 
 (extend-protocol TikaProtocol
   java.io.File
-  (parse [^File file] (with-open [is (input-stream file)] (parse is)))
+  (parse [^File file] (with-open [is (TikaInputStream/get (input-stream file))] (parse is)))
   (detect-mime-type [^File file] (.detect tika-class file)))
 
 (extend-protocol TikaProtocol
   String
-  (parse [^String filename] (with-open [is (input-stream filename)] (parse is)))
+  (parse [^String filename] (with-open [is (TikaInputStream/get (input-stream filename))] (parse is)))
   (detect-mime-type [^String filename] (.detect tika-class filename)))
 
 (extend-protocol TikaProtocol
   URL
-  (parse [^URL url] (with-open [is (input-stream url)] (parse is)))
+  (parse [^URL url] (with-open [is (TikaInputStream/get (input-stream url))] (parse is)))
   (detect-mime-type [^URL url] (.detect tika-class url)))
 
 (defn detect-language

--- a/src/tika.clj
+++ b/src/tika.clj
@@ -39,7 +39,8 @@
            (.parse parser ifile handler metadata context)
            (assoc (conv-metadata metadata) :text (.toString handler))))
   (detect-mime-type [^InputStream ifile]
-                    (.detect tika-class (TikaInputStream/get ifile))))
+    (with-open [in (TikaInputStream/get ifile)]
+      (.detect tika-class in))))
 
 (extend-protocol TikaProtocol
   java.io.File

--- a/src/tika.clj
+++ b/src/tika.clj
@@ -37,7 +37,7 @@
                ]
            (.set context Parser parser)
            (.parse parser ifile handler metadata context)
-           (assoc (conv-metadata metadata) :text (.toString handler))))
+           (assoc (conv-metadata metadata) :text (str handler))))
   (detect-mime-type [^InputStream ifile]
     (with-open [in (TikaInputStream/get ifile)]
       (.detect tika-class in))))


### PR DESCRIPTION
Due to the fact that nowaday many file formats are actually container formats (e.g. Office, mkv, ...) 
i wrapped the input-stream in a TikaInputStream.

The detection of information for container formats is only possible if you use TikaInputStream.
See http://tika.apache.org/1.2/detection.html#Content_Detection

This will consume more CPU and memory than the before.
So maybe take this pull-request with a grain of salt and find a good solution to furthermore 
make it possible to use the old behaviour.
